### PR TITLE
[experiment] Density token variable prefix (stacked on #48624)

### DIFF
--- a/docs/adr/0003-density-var-prefix.md
+++ b/docs/adr/0003-density-var-prefix.md
@@ -7,12 +7,48 @@
 
 ## Decision
 
-Component density tokens **carry the theme prefix, and the prefix tracks the css-var feature**:
+The **public** density tokens (the Material UI layer's designer knobs) **carry the theme
+prefix, and the prefix tracks the css-var feature**:
 
-- `createTheme({ cssVariables: true })` → `theme.cssVarPrefix` is `'mui'` (or custom) → tokens resolve to `--mui-Button-pad`.
-- plain `createTheme()` → no `cssVarPrefix` → tokens resolve to bare `--Button-pad`.
+- `createTheme({ cssVariables: true })` → `theme.cssVarPrefix` is `'mui'` (or custom) → `--mui-Button-small-pad`.
+- plain `createTheme()` → no `cssVarPrefix` → bare `--Button-small-pad`.
 
-The internal default `--_pad` is always **unprefixed** (private, co-located).
+The **agnostic seam** and the **internal default** are a different layer — see below.
+
+### The three layers map to three naming rules
+
+The adapter reads each component as three layers of responsibility (ADR-0001). The prefix
+decision applies **per layer**, not uniformly:
+
+| Layer | Owner | Token | Prefixed? | In `buttonVars`? |
+|---|---|---|---|---|
+| **Agnostic** | the bare styled root, no design opinion | `--comp-<key>` | **no** — literal | **no** |
+| **Material UI** | the public per-size designer knob | `--mui-Button-<size>-<key>` | yes (tracks feature) | **yes** |
+| **Internal default** | today's `(variant,size)` literal, in `variants` | `--_<key>` | no — literal | no |
+
+- The **agnostic seam** is the styled root's single consumption point. It must stay design-system-
+  agnostic, so it's the generic, literal `--comp-<key>` (e.g. `--comp-pad`, `--comp-padBlock`) —
+  **not** `--Button-pad`, which wrongly wore the component name and the theme prefix. It is **not**
+  a public designer knob, so it does **not** belong in `buttonVars` (which is the Material UI layer).
+- `buttonVars` therefore holds **only the public sized tokens** (`smallPad`, …) — the things a design
+  system actually tunes.
+
+```text
+--comp-pad                agnostic seam        ← styled root's consumption point; literal, unprefixed
+--mui-Button-<size>-pad   public sized token   ← designer knob; Material UI layer; tracks the prefix
+--_pad                    internal default     ← Material literal (in `variants`); literal, unprefixed
+```
+
+Consumption is unchanged in shape — the seam falls back to the internal default:
+`padding: var(--comp-pad, var(--_pad))`; each size variant routes the public token over the default
+into the seam: `'--comp-pad': var(--mui-Button-small-pad, var(--_pad))`.
+
+> **Caveat (generic seam inheritance).** Because `--comp-<key>` is generic (not component-scoped),
+> two *different* components that share a css key (e.g. both expose `pad`) and nest could inherit the
+> seam across the boundary if the inner root doesn't set it (custom sizes). In the current scope
+> (Button uses `pad`; OutlinedInput uses `padBlock`/`padInline`) the keys don't overlap, so there's no
+> collision. Mitigation when keys do overlap: every component root already sets its seam for built-in
+> sizes, which shadows any inherited value.
 
 ## How
 
@@ -33,15 +69,15 @@ export function makeComponentVars(keyMap) {        // cached by cssVarPrefix
 ```
 
 ```ts
-// Button/buttonVars.ts — the typed handle lives WITH the component
-export const buttonVars = { pad: 'Button-pad', smallPad: 'Button-small-pad', /* … */ } as const;
+// Button/buttonVars.ts — the typed handle lives WITH the component (public knobs only)
+export const buttonVars = { smallPad: 'Button-small-pad', /* mediumPad, largePad */ } as const;
 export const getButtonVars = makeComponentVars(buttonVars);
 ```
 
-- **Component internals** read `const v = getButtonVars(theme)` inside the styled fn (already
-  `memoTheme`-cached) and consume `var(${v.pad}, var(--_pad))`. No `theme.vars` branch, no
-  `|| 'mui'` fallback — works identically in both modes.
-- **Consumers** call the same `getButtonVars(theme)` for the bare name and set it:
+- **Component internals** read `const buttonVars = getButtonVars(theme)` inside the styled fn
+  (already `memoTheme`-cached), consume the literal seam `var(--comp-pad, var(--_pad))`, and route
+  the resolved public token into it per size. No `theme.vars` branch, no `|| 'mui'` fallback.
+- **Consumers** call the same `getButtonVars(theme)` for the bare public-token name and set it:
   `sx={{ [getButtonVars(theme).smallPad]: '2px 8px' }}`.
 
 ## Why these shapes (rejected alternatives)

--- a/docs/adr/0003-density-var-prefix.md
+++ b/docs/adr/0003-density-var-prefix.md
@@ -43,12 +43,13 @@ Consumption is unchanged in shape — the seam falls back to the internal defaul
 `padding: var(--comp-pad, var(--_pad))`; each size variant routes the public token over the default
 into the seam: `'--comp-pad': var(--mui-Button-small-pad, var(--_pad))`.
 
-> **Caveat (generic seam inheritance).** Because `--comp-<key>` is generic (not component-scoped),
-> two *different* components that share a css key (e.g. both expose `pad`) and nest could inherit the
-> seam across the boundary if the inner root doesn't set it (custom sizes). In the current scope
-> (Button uses `pad`; OutlinedInput uses `padBlock`/`padInline`) the keys don't overlap, so there's no
-> collision. Mitigation when keys do overlap: every component root already sets its seam for built-in
-> sizes, which shadows any inherited value.
+> **Generic seam + custom sizes.** A `--comp-<key>` seam is set on the root for every **built-in**
+> size (default + each size variant), so it never reads an inherited value there — a same-named seam on
+> an ancestor is shadowed. The only seam-unset path is a **custom** (theme-added) size, and those are
+> deliberately **out of density scope** (no inline routing; they render the literal `--_pad`). So the
+> theoretical "two components share a css key and a custom-size inner one inherits the outer's seam"
+> case is a documented non-goal, not a live risk. (A design system that adds a dense custom size sets
+> the literal seam itself.)
 
 ## How
 
@@ -93,10 +94,13 @@ export const getButtonVars = makeComponentVars(buttonVars);
 - **Forcing `cssVarPrefix: 'mui'` on every theme (rejected).** Would give one stable name in
   all modes, but bolts a css-var concept onto non-css-var themes and needs a `createThemeNoVars`
   change. Since both sides share `getButtonVars`, names match without it.
-- **Custom-size inline token routing (dropped).** It required a `useTheme()` call in render
-  purely to name a token. Custom sizes now fall back to `--_pad`; only built-in sizes get
-  per-size tokens (handled in `variants`, which already have `theme`). One hook removed from
-  every Button render.
+- **Custom-size inline token routing (dropped — custom sizes are out of density scope).** The
+  unprefixed prototype routed custom sizes inline (`style={{ '--comp-pad': 'var(--Button-xl-pad)' }}`)
+  for free, since the token name was a static string. Prefixing makes that inline name
+  theme-dependent (a `useTheme()` in render). Rather than pay that for a rare path, custom sizes are
+  excluded from density: they render `--_pad`; only built-in sizes get per-size tokens (in `variants`,
+  which already have `theme`). This is itself a small, concrete **cost of prefixing** — in the
+  unprefixed design custom-size routing is free.
 
 ## Cost the team is being asked to accept
 

--- a/docs/adr/0003-density-var-prefix.md
+++ b/docs/adr/0003-density-var-prefix.md
@@ -1,0 +1,89 @@
+# ADR 0003 — Density token variable prefix & access
+
+> Status: **experiment** (branch `exp/density-var-prefix`, off `exp/css-var-density-adapter` / PR #48624)
+> Feeds the RFC's open question 1 ("Variable prefix + var-access API"). Goal of the branch:
+> find the *cleanest* way to make prefixing work, so the team can judge whether the added
+> complexity is acceptable — i.e. measure the real floor, not an inflated cost.
+
+## Decision
+
+Component density tokens **carry the theme prefix, and the prefix tracks the css-var feature**:
+
+- `createTheme({ cssVariables: true })` → `theme.cssVarPrefix` is `'mui'` (or custom) → tokens resolve to `--mui-Button-pad`.
+- plain `createTheme()` → no `cssVarPrefix` → tokens resolve to bare `--Button-pad`.
+
+The internal default `--_pad` is always **unprefixed** (private, co-located).
+
+## How
+
+One resolver, used by **both** the styled component and the consumer, so the emitted name
+and the targeted name are produced by the same function on the same theme and cannot drift:
+
+```ts
+// styles/tokenAccess.ts
+export function makeComponentVars(keyMap) {        // cached by cssVarPrefix
+  const cache = new Map();
+  return (theme) => {
+    const prefix = theme?.cssVarPrefix ?? '';
+    let vars = cache.get(prefix);
+    if (!vars) { vars = Object.freeze(mapNames(keyMap, prefix)); cache.set(prefix, vars); }
+    return vars;
+  };
+}
+```
+
+```ts
+// Button/buttonVars.ts — the typed handle lives WITH the component
+export const buttonVars = { pad: 'Button-pad', smallPad: 'Button-small-pad', /* … */ } as const;
+export const getButtonVars = makeComponentVars(buttonVars);
+```
+
+- **Component internals** read `const v = getButtonVars(theme)` inside the styled fn (already
+  `memoTheme`-cached) and consume `var(${v.pad}, var(--_pad))`. No `theme.vars` branch, no
+  `|| 'mui'` fallback — works identically in both modes.
+- **Consumers** call the same `getButtonVars(theme)` for the bare name and set it:
+  `sx={{ [getButtonVars(theme).smallPad]: '2px 8px' }}`.
+
+## Why these shapes (rejected alternatives)
+
+- **`theme.vars.Button.smallPad` (rejected).** A core-assembled `theme.vars` node would force
+  `createTheme` to import every component's var map — a dependency inversion (core → leaf
+  components), kills tree-shaking, and a `Proxy` workaround fights Pigment's theme
+  serialization. The component's `buttonVars` key map is the typed handle instead.
+- **`theme.getCssVar` (rejected for tokens).** It returns the wrapped read form
+  `var(--mui-…)`, which is invalid as a custom-property *key* — useless for the dominant
+  action (setting a token). It's also absent on a plain `createTheme()` theme. `getButtonVars`
+  returns the bare name, works in both modes, and covers set + (wrap-it-yourself) read.
+- **Forcing `cssVarPrefix: 'mui'` on every theme (rejected).** Would give one stable name in
+  all modes, but bolts a css-var concept onto non-css-var themes and needs a `createThemeNoVars`
+  change. Since both sides share `getButtonVars`, names match without it.
+- **Custom-size inline token routing (dropped).** It required a `useTheme()` call in render
+  purely to name a token. Custom sizes now fall back to `--_pad`; only built-in sizes get
+  per-size tokens (handled in `variants`, which already have `theme`). One hook removed from
+  every Button render.
+
+## Cost the team is being asked to accept
+
+1. **Mode-dependent public name** — `--mui-Button-*` with `cssVariables`, `--Button-*` without.
+   Fine within one app; the casualty is cross-mode preset portability (a preset authored as
+   `--mui-*` does nothing pasted into a no-vars app), and docs must show the name per mode.
+2. **Tokens are theme-resolved, not static strings** — a consumer must call `getButtonVars(theme)`
+   rather than hand-type a constant. Mitigated: it's one cached call; bare names; typed keys.
+
+Everything else that looked expensive in the first cut (a hook per render, a parallel naming
+scheme, a `theme.vars` assembly, build-time questions) was removable. This is the floor.
+
+## Performance
+
+`getButtonVars` is memoized by `cssVarPrefix` (domain ≈ `{ '', 'mui' }`): first call builds +
+freezes the map, every later call is an O(1) `Map.get` returning the shared object — no
+per-call allocation, multi-field free. Component internals are additionally inside `memoTheme`.
+
+## Branch staleness
+
+Pre-existing density demos/harness (`density-tokens`, `density-showcase`, `density-fixture`,
+`scripts/density-screenshots`) hand-author tokens as `--Button-*` / `--OutlinedInput-*`. Under
+`cssVariables: true` the components now emit `--mui-*`, so those override scopes no longer drive
+the three converted components on this branch. The **default** (no-token) render is unchanged
+(a consistent rename, not a value change) → Argos zero-diff holds. Only the explicit-override
+scopes need re-pointing if this direction is adopted.

--- a/docs/pages/experiments/density-var-prefix.tsx
+++ b/docs/pages/experiments/density-var-prefix.tsx
@@ -1,0 +1,170 @@
+'use client';
+import * as React from 'react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import Box from '@mui/material/Box';
+import Button, { getButtonVars } from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Divider from '@mui/material/Divider';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import { AppLayoutHead as Head } from '@mui/internal-core-docs/AppLayout';
+
+// Var-prefix experiment (docs/adr/0003-density-var-prefix.md). The prefix tracks
+// the css-var feature: a theme created with `cssVariables` carries a
+// `cssVarPrefix` (default "mui"), so density tokens resolve to `--mui-Button-*`;
+// a plain `createTheme()` has none, so they resolve to bare `--Button-*`.
+// The styled component AND the consumer both resolve names through the SAME
+// `getButtonVars(theme)`, so the emitted name and the targeted name can never
+// drift. No `theme.vars.*`, no `getCssVar`, no forced prefix.
+
+const THEMES = [
+  { id: 'plain', label: 'createTheme()', theme: createTheme() },
+  {
+    id: 'vars',
+    label: 'createTheme({ cssVariables: true })',
+    theme: createTheme({ cssVariables: true }),
+  },
+  {
+    id: 'acme',
+    label: "createTheme({ cssVariables: { cssVarPrefix: 'acme' } })",
+    theme: createTheme({ cssVariables: { cssVarPrefix: 'acme' } }),
+  },
+];
+
+const codeSx = {
+  fontFamily: 'monospace',
+  fontSize: 13,
+  bgcolor: 'action.hover',
+  px: 0.5,
+  borderRadius: 0.5,
+} as const;
+
+function Column({ label, theme }: { label: string; theme: any }) {
+  const [pad, setPad] = React.useState('2px 8px');
+  // Consumer resolves the bare token name through the SAME resolver the
+  // component uses — so this override targets exactly what the component reads.
+  const v = getButtonVars(theme);
+  const scope = { [v.smallPad]: pad } as React.CSSProperties;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 0 }}>
+      <Box component="code" sx={{ ...codeSx, display: 'block', mb: 1, whiteSpace: 'normal' }}>
+        {label}
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+        getButtonVars(theme).smallPad →
+      </Typography>
+      <Chip
+        size="small"
+        color="primary"
+        label={v.smallPad}
+        sx={{ mb: 2, fontFamily: 'monospace' }}
+      />
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Stack direction="row" spacing={2} alignItems="center">
+          <div>
+            <Typography variant="overline" display="block">
+              default
+            </Typography>
+            <Button variant="contained" size="small">
+              small
+            </Button>
+          </div>
+          <Box style={scope}>
+            <Typography variant="overline" display="block">
+              overridden
+            </Typography>
+            <Button variant="contained" size="small">
+              small
+            </Button>
+          </Box>
+        </Stack>
+      </ThemeProvider>
+      <TextField
+        label={`set ${v.smallPad}`}
+        value={pad}
+        onChange={(event) => setPad(event.target.value)}
+        size="small"
+        fullWidth
+        sx={{ mt: 2 }}
+      />
+    </Paper>
+  );
+}
+
+export default function DensityVarPrefix() {
+  return (
+    <Box sx={{ maxWidth: 1100, mx: 'auto', p: { xs: 2, md: 4 } }}>
+      <Head
+        title="Density var-prefix experiment"
+        description="Prefixed density tokens whose prefix tracks the css-var feature, resolved by one shared helper."
+      />
+      <Typography variant="h4" gutterBottom>
+        Density tokens — variable prefix
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 3 }}>
+        Component density tokens carry the theme prefix — but the prefix{' '}
+        <strong>tracks the css-var feature</strong>. A theme made with{' '}
+        <Box component="code" sx={codeSx}>
+          cssVariables
+        </Box>{' '}
+        resolves tokens to{' '}
+        <Box component="code" sx={codeSx}>
+          --mui-Button-pad
+        </Box>{' '}
+        (or your custom prefix); a plain{' '}
+        <Box component="code" sx={codeSx}>
+          createTheme()
+        </Box>{' '}
+        resolves them to bare{' '}
+        <Box component="code" sx={codeSx}>
+          --Button-pad
+        </Box>
+        . The styled component and the consumer below both resolve through the same{' '}
+        <Box component="code" sx={codeSx}>
+          getButtonVars(theme)
+        </Box>
+        , so the override always lands — in every mode.
+      </Typography>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mb: 4 }}>
+        {THEMES.map((t) => (
+          <Column key={t.id} label={t.label} theme={t.theme} />
+        ))}
+      </Stack>
+
+      <Divider sx={{ my: 4 }} />
+
+      <Typography variant="h6" gutterBottom>
+        The whole consumer API
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        One import, one call. Bare names (usable as a custom-property key), resolved per theme,
+        cached by prefix. No{' '}
+        <Box component="code" sx={codeSx}>
+          theme.vars.Button
+        </Box>
+        , no{' '}
+        <Box component="code" sx={codeSx}>
+          getCssVar
+        </Box>
+        .
+      </Typography>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Box component="pre" sx={{ m: 0, fontSize: 13, overflow: 'auto' }}>
+          {`import { getButtonVars } from '@mui/material/Button';
+
+function Compact({ children }) {
+  const theme = useTheme();
+  const v = getButtonVars(theme);
+  return <Box sx={{ [v.smallPad]: '2px 8px' }}>{children}</Box>;
+}`}
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/docs/pages/experiments/density-var-prefix.tsx
+++ b/docs/pages/experiments/density-var-prefix.tsx
@@ -12,13 +12,14 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import { AppLayoutHead as Head } from '@mui/internal-core-docs/AppLayout';
 
-// Var-prefix experiment (docs/adr/0003-density-var-prefix.md). The prefix tracks
-// the css-var feature: a theme created with `cssVariables` carries a
-// `cssVarPrefix` (default "mui"), so density tokens resolve to `--mui-Button-*`;
-// a plain `createTheme()` has none, so they resolve to bare `--Button-*`.
-// The styled component AND the consumer both resolve names through the SAME
-// `getButtonVars(theme)`, so the emitted name and the targeted name can never
-// drift. No `theme.vars.*`, no `getCssVar`, no forced prefix.
+// Var-prefix experiment (docs/adr/0003-density-var-prefix.md). The PUBLIC token
+// (the Material UI layer's designer knob) carries the prefix, which tracks the
+// css-var feature: a theme with `cssVariables` resolves it to
+// `--mui-Button-small-pad`; a plain `createTheme()` to bare `--Button-small-pad`.
+// The agnostic seam (`--comp-pad`) and internal default (`--_pad`) are a separate,
+// literal/unprefixed layer and aren't in `buttonVars`. The styled component AND
+// the consumer both resolve the public token through the SAME `getButtonVars(theme)`,
+// so emitted and targeted names can't drift. No `theme.vars.*`, no `getCssVar`.
 
 const THEMES = [
   { id: 'plain', label: 'createTheme()', theme: createTheme() },
@@ -107,24 +108,29 @@ export default function DensityVarPrefix() {
         Density tokens — variable prefix
       </Typography>
       <Typography color="text.secondary" sx={{ mb: 3 }}>
-        Component density tokens carry the theme prefix — but the prefix{' '}
+        The <strong>public token</strong> (the designer knob) carries the prefix — but the prefix{' '}
         <strong>tracks the css-var feature</strong>. A theme made with{' '}
         <Box component="code" sx={codeSx}>
           cssVariables
         </Box>{' '}
-        resolves tokens to{' '}
+        resolves it to{' '}
         <Box component="code" sx={codeSx}>
-          --mui-Button-pad
+          --mui-Button-small-pad
         </Box>{' '}
         (or your custom prefix); a plain{' '}
         <Box component="code" sx={codeSx}>
           createTheme()
         </Box>{' '}
-        resolves them to bare{' '}
+        to bare{' '}
         <Box component="code" sx={codeSx}>
-          --Button-pad
+          --Button-small-pad
         </Box>
-        . The styled component and the consumer below both resolve through the same{' '}
+        . The agnostic seam{' '}
+        <Box component="code" sx={codeSx}>
+          --comp-pad
+        </Box>{' '}
+        stays literal/unprefixed. The styled component and the consumer below both resolve the
+        public token through the same{' '}
         <Box component="code" sx={codeSx}>
           getButtonVars(theme)
         </Box>

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -94,10 +94,11 @@ const ButtonRoot = styled(ButtonBase, {
   },
 })(
   memoTheme(({ theme }) => {
-    // Resolve the public density token names through the same helper consumers
-    // use (ADR-0003), so the emitted and targeted names can't drift. The prefix
-    // tracks the css-var feature: `--mui-Button-pad` with cssVariables, bare
-    // `--Button-pad` without. The internal `--_pad` default stays unprefixed.
+    // Material UI layer: resolve the public sized tokens through the same helper
+    // consumers use (ADR-0003), so emitted and targeted names can't drift. The
+    // prefix tracks the css-var feature: `--mui-Button-small-pad` with
+    // cssVariables, bare `--Button-small-pad` without. The agnostic seam
+    // (`--comp-pad`) and internal default (`--_pad`) are literal and unprefixed.
     const buttonVars = getButtonVars(theme);
 
     const inheritContainedBackgroundColor =
@@ -107,11 +108,12 @@ const ButtonRoot = styled(ButtonBase, {
       theme.palette.mode === 'light' ? theme.palette.grey.A100 : theme.palette.grey[700];
     return {
       ...theme.typography.button,
-      // Agnostic layer: the only spacing surface the styled root reads. `--_pad`
-      // is the universal default (today's root padding); variants specialize it
-      // per (variant, size), so a custom variant/size still gets a sane value.
+      // Agnostic layer: the styled root's single consumption point reads the
+      // literal, unprefixed seam `--comp-pad`. `--_pad` is the universal default
+      // (today's root padding); variants specialize it per (variant, size), so a
+      // custom variant/size still gets a sane value.
       '--_pad': '6px 16px',
-      padding: `var(${buttonVars.pad}, var(--_pad))`, // seam falls back to the internal default
+      padding: 'var(--comp-pad, var(--_pad))', // seam falls back to the internal default
       minWidth: 64,
       border: 0,
       borderRadius: (theme.vars || theme).shape.borderRadius,
@@ -126,19 +128,19 @@ const ButtonRoot = styled(ButtonBase, {
       },
       variants: [
         // Built-in size routing (CSS, deduped) — routes the public sized token
-        // over the internal default. A custom size matches none of these, so its
-        // seam stays unset and consumption falls back to `--_pad`.
+        // over the internal default into the agnostic seam. A custom size matches
+        // none of these, so the seam stays unset and consumption falls to `--_pad`.
         {
           props: { size: 'small' },
-          style: { [buttonVars.pad]: `var(${buttonVars.smallPad}, var(--_pad))` },
+          style: { '--comp-pad': `var(${buttonVars.smallPad}, var(--_pad))` },
         },
         {
           props: { size: 'medium' },
-          style: { [buttonVars.pad]: `var(${buttonVars.mediumPad}, var(--_pad))` },
+          style: { '--comp-pad': `var(${buttonVars.mediumPad}, var(--_pad))` },
         },
         {
           props: { size: 'large' },
-          style: { [buttonVars.pad]: `var(${buttonVars.largePad}, var(--_pad))` },
+          style: { '--comp-pad': `var(${buttonVars.largePad}, var(--_pad))` },
         },
         {
           props: { variant: 'contained' },

--- a/packages/mui-material/src/Button/Button.js
+++ b/packages/mui-material/src/Button/Button.js
@@ -7,6 +7,7 @@ import composeClasses from '@mui/utils/composeClasses';
 import { unstable_useId as useId } from '../utils';
 import rootShouldForwardProp from '../styles/rootShouldForwardProp';
 import { styled } from '../zero-styled';
+import { getButtonVars } from './buttonVars';
 import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
 import ButtonBase from '../ButtonBase';
@@ -74,9 +75,6 @@ const commonIconStyles = [
   },
 ];
 
-// Built-in sizes route padding via variants; any other size routes inline.
-const buttonSizes = ['small', 'medium', 'large'];
-
 const ButtonRoot = styled(ButtonBase, {
   shouldForwardProp: (prop) => rootShouldForwardProp(prop) || prop === 'classes',
   name: 'MuiButton',
@@ -96,6 +94,12 @@ const ButtonRoot = styled(ButtonBase, {
   },
 })(
   memoTheme(({ theme }) => {
+    // Resolve the public density token names through the same helper consumers
+    // use (ADR-0003), so the emitted and targeted names can't drift. The prefix
+    // tracks the css-var feature: `--mui-Button-pad` with cssVariables, bare
+    // `--Button-pad` without. The internal `--_pad` default stays unprefixed.
+    const buttonVars = getButtonVars(theme);
+
     const inheritContainedBackgroundColor =
       theme.palette.mode === 'light' ? theme.palette.grey[300] : theme.palette.grey[800];
 
@@ -107,7 +111,7 @@ const ButtonRoot = styled(ButtonBase, {
       // is the universal default (today's root padding); variants specialize it
       // per (variant, size), so a custom variant/size still gets a sane value.
       '--_pad': '6px 16px',
-      padding: 'var(--Button-pad, var(--_pad))',
+      padding: `var(${buttonVars.pad}, var(--_pad))`, // seam falls back to the internal default
       minWidth: 64,
       border: 0,
       borderRadius: (theme.vars || theme).shape.borderRadius,
@@ -121,19 +125,20 @@ const ButtonRoot = styled(ButtonBase, {
         color: (theme.vars || theme).palette.action.disabled,
       },
       variants: [
-        // Built-in size routing (CSS, deduped) — exposes the public sized token
-        // over the internal default. Custom sizes are routed inline instead.
+        // Built-in size routing (CSS, deduped) — routes the public sized token
+        // over the internal default. A custom size matches none of these, so its
+        // seam stays unset and consumption falls back to `--_pad`.
         {
           props: { size: 'small' },
-          style: { '--Button-pad': 'var(--Button-small-pad, var(--_pad))' },
+          style: { [buttonVars.pad]: `var(${buttonVars.smallPad}, var(--_pad))` },
         },
         {
           props: { size: 'medium' },
-          style: { '--Button-pad': 'var(--Button-medium-pad, var(--_pad))' },
+          style: { [buttonVars.pad]: `var(${buttonVars.mediumPad}, var(--_pad))` },
         },
         {
           props: { size: 'large' },
-          style: { '--Button-pad': 'var(--Button-large-pad, var(--_pad))' },
+          style: { [buttonVars.pad]: `var(${buttonVars.largePad}, var(--_pad))` },
         },
         {
           props: { variant: 'contained' },
@@ -567,14 +572,6 @@ const Button = React.forwardRef(function Button(inProps, ref) {
 
   const classes = useUtilityClasses(ownerState);
 
-  // Material UI layer: built-in sizes route the public sized token via variants
-  // (deduped CSS). A custom size has no such variant, so route it inline — the
-  // token name carries the runtime size string, keeping custom sizes tunable for
-  // free. The `--_pad` default lives in the variants. See docs/adr/0001.
-  const densityVars = buttonSizes.includes(size)
-    ? undefined
-    : { '--Button-pad': `var(--Button-${size}-pad, var(--_pad))` };
-
   const startIcon = (startIconProp || (loading && loadingPosition === 'start')) && (
     <ButtonStartIcon className={classes.startIcon} ownerState={ownerState}>
       {startIconProp || (
@@ -627,7 +624,6 @@ const Button = React.forwardRef(function Button(inProps, ref) {
       type={type}
       id={loading ? loadingId : idProp}
       {...other}
-      style={{ ...densityVars, ...other.style }}
       classes={forwardedClasses}
     >
       {startIcon}

--- a/packages/mui-material/src/Button/buttonVars.ts
+++ b/packages/mui-material/src/Button/buttonVars.ts
@@ -1,0 +1,23 @@
+import { makeComponentVars } from '../styles/tokenAccess';
+
+/**
+ * Button density token identities (ADR-0003) — unprefixed keys, the typed
+ * handle a consumer imports. `pad` is the agnostic seam; the sized keys are the
+ * public designer knobs.
+ */
+export const buttonVars = {
+  pad: 'Button-pad',
+  smallPad: 'Button-small-pad',
+  mediumPad: 'Button-medium-pad',
+  largePad: 'Button-large-pad',
+} as const;
+
+/**
+ * Resolve the bare, prefix-aware var names for a theme — used by the styled
+ * component AND by consumers, so the names always match.
+ *
+ * @example
+ * const v = getButtonVars(theme); // v.smallPad === '--mui-Button-small-pad' (cssVariables) | '--Button-small-pad' (plain)
+ * <Box sx={{ [v.smallPad]: '2px 8px' }} />
+ */
+export const getButtonVars = makeComponentVars(buttonVars);

--- a/packages/mui-material/src/Button/buttonVars.ts
+++ b/packages/mui-material/src/Button/buttonVars.ts
@@ -1,12 +1,12 @@
 import { makeComponentVars } from '../styles/tokenAccess';
 
 /**
- * Button density token identities (ADR-0003) — unprefixed keys, the typed
- * handle a consumer imports. `pad` is the agnostic seam; the sized keys are the
- * public designer knobs.
+ * Button density token identities (ADR-0003) — the Material UI layer's public
+ * designer knobs (prefixed via `getButtonVars`), the typed handle a consumer
+ * imports. The agnostic seam (`--comp-pad`) and internal default (`--_pad`) are
+ * the literal, unprefixed plumbing and deliberately live outside this map.
  */
 export const buttonVars = {
-  pad: 'Button-pad',
   smallPad: 'Button-small-pad',
   mediumPad: 'Button-medium-pad',
   largePad: 'Button-large-pad',

--- a/packages/mui-material/src/Button/index.js
+++ b/packages/mui-material/src/Button/index.js
@@ -2,3 +2,5 @@ export { default } from './Button';
 
 export { default as buttonClasses } from './buttonClasses';
 export * from './buttonClasses';
+
+export { buttonVars, getButtonVars } from './buttonVars';

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -12,7 +12,6 @@ import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
 import { getInputLabelUtilityClasses } from './inputLabelClasses';
 import { getTransitionStyles } from '../transitions/utils';
-import { varName } from '../styles/tokenAccess';
 
 const useUtilityClasses = (ownerState) => {
   const { classes, formControl, size, shrink, disableAnimation, variant, required } = ownerState;
@@ -54,130 +53,126 @@ const InputLabelRoot = styled(FormLabel, {
     ];
   },
 })(
-  memoTheme(({ theme }) => {
-    // Seam driven by OutlinedInput's `:has` bridge; honors cssVarPrefix. ADR-0003.
-    const labelY = varName(theme, 'InputLabel-y');
-    return {
-      display: 'block',
-      transformOrigin: 'top left',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      maxWidth: '100%',
-      variants: [
-        {
-          props: ({ ownerState }) => ownerState.formControl,
-          style: {
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            // slight alteration to spec spacing to match visual spec result
-            transform: 'translate(0, 20px) scale(1)',
-          },
+  memoTheme(({ theme }) => ({
+    display: 'block',
+    transformOrigin: 'top left',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    maxWidth: '100%',
+    variants: [
+      {
+        props: ({ ownerState }) => ownerState.formControl,
+        style: {
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          // slight alteration to spec spacing to match visual spec result
+          transform: 'translate(0, 20px) scale(1)',
         },
-        {
-          props: {
-            size: 'small',
-          },
-          style: {
-            // Compensation for the `Input` small size style.
-            transform: 'translate(0, 17px) scale(1)',
-          },
+      },
+      {
+        props: {
+          size: 'small',
         },
-        {
-          props: ({ ownerState }) => ownerState.shrink,
-          style: {
-            transform: 'translate(0, -1.5px) scale(0.75)',
-            transformOrigin: 'top left',
-            maxWidth: '133%',
-          },
+        style: {
+          // Compensation for the `Input` small size style.
+          transform: 'translate(0, 17px) scale(1)',
         },
-        {
-          props: ({ ownerState }) => !ownerState.disableAnimation,
-          style: {
-            ...getTransitionStyles(theme, ['color', 'transform', 'max-width'], {
-              duration: theme.transitions.duration.shorter,
-              easing: theme.transitions.easing.easeOut,
-            }),
-          },
+      },
+      {
+        props: ({ ownerState }) => ownerState.shrink,
+        style: {
+          transform: 'translate(0, -1.5px) scale(0.75)',
+          transformOrigin: 'top left',
+          maxWidth: '133%',
         },
-        {
-          props: {
-            variant: 'filled',
-          },
-          style: {
-            // Chrome's autofill feature gives the input field a yellow background.
-            // Since the input field is behind the label in the HTML tree,
-            // the input field is drawn last and hides the label with an opaque background color.
-            // zIndex: 1 will raise the label above opaque background-colors of input.
-            zIndex: 1,
-            pointerEvents: 'none',
-            transform: 'translate(12px, 16px) scale(1)',
-            maxWidth: 'calc(100% - 24px)',
-          },
+      },
+      {
+        props: ({ ownerState }) => !ownerState.disableAnimation,
+        style: {
+          ...getTransitionStyles(theme, ['color', 'transform', 'max-width'], {
+            duration: theme.transitions.duration.shorter,
+            easing: theme.transitions.easing.easeOut,
+          }),
         },
-        {
-          props: {
-            variant: 'filled',
-            size: 'small',
-          },
-          style: {
-            transform: 'translate(12px, 13px) scale(1)',
-          },
+      },
+      {
+        props: {
+          variant: 'filled',
         },
-        {
-          props: ({ variant, ownerState }) => variant === 'filled' && ownerState.shrink,
-          style: {
-            userSelect: 'none',
-            pointerEvents: 'auto',
-            transform: 'translate(12px, 7px) scale(0.75)',
-            maxWidth: 'calc(133% - 24px)',
-          },
+        style: {
+          // Chrome's autofill feature gives the input field a yellow background.
+          // Since the input field is behind the label in the HTML tree,
+          // the input field is drawn last and hides the label with an opaque background color.
+          // zIndex: 1 will raise the label above opaque background-colors of input.
+          zIndex: 1,
+          pointerEvents: 'none',
+          transform: 'translate(12px, 16px) scale(1)',
+          maxWidth: 'calc(100% - 24px)',
         },
-        {
-          props: ({ variant, ownerState, size }) =>
-            variant === 'filled' && ownerState.shrink && size === 'small',
-          style: {
-            transform: 'translate(12px, 4px) scale(0.75)',
-          },
+      },
+      {
+        props: {
+          variant: 'filled',
+          size: 'small',
         },
-        {
-          props: {
-            variant: 'outlined',
-          },
-          style: {
-            // see comment above on filled.zIndex
-            zIndex: 1,
-            pointerEvents: 'none',
-            // Resting Y is a generic seam; the sibling input owns its value (see
-            // OutlinedInput's `:has` rule). Default is today's literal.
-            transform: `translate(14px, var(${labelY}, 16px)) scale(1)`,
-            maxWidth: 'calc(100% - 24px)',
-          },
+        style: {
+          transform: 'translate(12px, 13px) scale(1)',
         },
-        {
-          props: {
-            variant: 'outlined',
-            size: 'small',
-          },
-          style: {
-            transform: `translate(14px, var(${labelY}, 9px)) scale(1)`,
-          },
+      },
+      {
+        props: ({ variant, ownerState }) => variant === 'filled' && ownerState.shrink,
+        style: {
+          userSelect: 'none',
+          pointerEvents: 'auto',
+          transform: 'translate(12px, 7px) scale(0.75)',
+          maxWidth: 'calc(133% - 24px)',
         },
-        {
-          props: ({ variant, ownerState }) => variant === 'outlined' && ownerState.shrink,
-          style: {
-            userSelect: 'none',
-            pointerEvents: 'auto',
-            // Theoretically, we should have (8+5)*2/0.75 = 34px
-            // but it feels a better when it bleeds a bit on the left, so 32px.
-            maxWidth: 'calc(133% - 32px)',
-            transform: 'translate(14px, -9px) scale(0.75)',
-          },
+      },
+      {
+        props: ({ variant, ownerState, size }) =>
+          variant === 'filled' && ownerState.shrink && size === 'small',
+        style: {
+          transform: 'translate(12px, 4px) scale(0.75)',
         },
-      ],
-    };
-  }),
+      },
+      {
+        props: {
+          variant: 'outlined',
+        },
+        style: {
+          // see comment above on filled.zIndex
+          zIndex: 1,
+          pointerEvents: 'none',
+          // Resting Y is a generic seam; the sibling input owns its value (see
+          // OutlinedInput's `:has` rule). Default is today's literal.
+          transform: 'translate(14px, var(--comp-labelY, 16px)) scale(1)',
+          maxWidth: 'calc(100% - 24px)',
+        },
+      },
+      {
+        props: {
+          variant: 'outlined',
+          size: 'small',
+        },
+        style: {
+          transform: 'translate(14px, var(--comp-labelY, 9px)) scale(1)',
+        },
+      },
+      {
+        props: ({ variant, ownerState }) => variant === 'outlined' && ownerState.shrink,
+        style: {
+          userSelect: 'none',
+          pointerEvents: 'auto',
+          // Theoretically, we should have (8+5)*2/0.75 = 34px
+          // but it feels a better when it bleeds a bit on the left, so 32px.
+          maxWidth: 'calc(133% - 32px)',
+          transform: 'translate(14px, -9px) scale(0.75)',
+        },
+      },
+    ],
+  })),
 );
 
 const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {

--- a/packages/mui-material/src/InputLabel/InputLabel.js
+++ b/packages/mui-material/src/InputLabel/InputLabel.js
@@ -12,6 +12,7 @@ import memoTheme from '../utils/memoTheme';
 import { useDefaultProps } from '../DefaultPropsProvider';
 import { getInputLabelUtilityClasses } from './inputLabelClasses';
 import { getTransitionStyles } from '../transitions/utils';
+import { varName } from '../styles/tokenAccess';
 
 const useUtilityClasses = (ownerState) => {
   const { classes, formControl, size, shrink, disableAnimation, variant, required } = ownerState;
@@ -53,126 +54,130 @@ const InputLabelRoot = styled(FormLabel, {
     ];
   },
 })(
-  memoTheme(({ theme }) => ({
-    display: 'block',
-    transformOrigin: 'top left',
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    maxWidth: '100%',
-    variants: [
-      {
-        props: ({ ownerState }) => ownerState.formControl,
-        style: {
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          // slight alteration to spec spacing to match visual spec result
-          transform: 'translate(0, 20px) scale(1)',
+  memoTheme(({ theme }) => {
+    // Seam driven by OutlinedInput's `:has` bridge; honors cssVarPrefix. ADR-0003.
+    const labelY = varName(theme, 'InputLabel-y');
+    return {
+      display: 'block',
+      transformOrigin: 'top left',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      maxWidth: '100%',
+      variants: [
+        {
+          props: ({ ownerState }) => ownerState.formControl,
+          style: {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            // slight alteration to spec spacing to match visual spec result
+            transform: 'translate(0, 20px) scale(1)',
+          },
         },
-      },
-      {
-        props: {
-          size: 'small',
+        {
+          props: {
+            size: 'small',
+          },
+          style: {
+            // Compensation for the `Input` small size style.
+            transform: 'translate(0, 17px) scale(1)',
+          },
         },
-        style: {
-          // Compensation for the `Input` small size style.
-          transform: 'translate(0, 17px) scale(1)',
+        {
+          props: ({ ownerState }) => ownerState.shrink,
+          style: {
+            transform: 'translate(0, -1.5px) scale(0.75)',
+            transformOrigin: 'top left',
+            maxWidth: '133%',
+          },
         },
-      },
-      {
-        props: ({ ownerState }) => ownerState.shrink,
-        style: {
-          transform: 'translate(0, -1.5px) scale(0.75)',
-          transformOrigin: 'top left',
-          maxWidth: '133%',
+        {
+          props: ({ ownerState }) => !ownerState.disableAnimation,
+          style: {
+            ...getTransitionStyles(theme, ['color', 'transform', 'max-width'], {
+              duration: theme.transitions.duration.shorter,
+              easing: theme.transitions.easing.easeOut,
+            }),
+          },
         },
-      },
-      {
-        props: ({ ownerState }) => !ownerState.disableAnimation,
-        style: {
-          ...getTransitionStyles(theme, ['color', 'transform', 'max-width'], {
-            duration: theme.transitions.duration.shorter,
-            easing: theme.transitions.easing.easeOut,
-          }),
+        {
+          props: {
+            variant: 'filled',
+          },
+          style: {
+            // Chrome's autofill feature gives the input field a yellow background.
+            // Since the input field is behind the label in the HTML tree,
+            // the input field is drawn last and hides the label with an opaque background color.
+            // zIndex: 1 will raise the label above opaque background-colors of input.
+            zIndex: 1,
+            pointerEvents: 'none',
+            transform: 'translate(12px, 16px) scale(1)',
+            maxWidth: 'calc(100% - 24px)',
+          },
         },
-      },
-      {
-        props: {
-          variant: 'filled',
+        {
+          props: {
+            variant: 'filled',
+            size: 'small',
+          },
+          style: {
+            transform: 'translate(12px, 13px) scale(1)',
+          },
         },
-        style: {
-          // Chrome's autofill feature gives the input field a yellow background.
-          // Since the input field is behind the label in the HTML tree,
-          // the input field is drawn last and hides the label with an opaque background color.
-          // zIndex: 1 will raise the label above opaque background-colors of input.
-          zIndex: 1,
-          pointerEvents: 'none',
-          transform: 'translate(12px, 16px) scale(1)',
-          maxWidth: 'calc(100% - 24px)',
+        {
+          props: ({ variant, ownerState }) => variant === 'filled' && ownerState.shrink,
+          style: {
+            userSelect: 'none',
+            pointerEvents: 'auto',
+            transform: 'translate(12px, 7px) scale(0.75)',
+            maxWidth: 'calc(133% - 24px)',
+          },
         },
-      },
-      {
-        props: {
-          variant: 'filled',
-          size: 'small',
+        {
+          props: ({ variant, ownerState, size }) =>
+            variant === 'filled' && ownerState.shrink && size === 'small',
+          style: {
+            transform: 'translate(12px, 4px) scale(0.75)',
+          },
         },
-        style: {
-          transform: 'translate(12px, 13px) scale(1)',
+        {
+          props: {
+            variant: 'outlined',
+          },
+          style: {
+            // see comment above on filled.zIndex
+            zIndex: 1,
+            pointerEvents: 'none',
+            // Resting Y is a generic seam; the sibling input owns its value (see
+            // OutlinedInput's `:has` rule). Default is today's literal.
+            transform: `translate(14px, var(${labelY}, 16px)) scale(1)`,
+            maxWidth: 'calc(100% - 24px)',
+          },
         },
-      },
-      {
-        props: ({ variant, ownerState }) => variant === 'filled' && ownerState.shrink,
-        style: {
-          userSelect: 'none',
-          pointerEvents: 'auto',
-          transform: 'translate(12px, 7px) scale(0.75)',
-          maxWidth: 'calc(133% - 24px)',
+        {
+          props: {
+            variant: 'outlined',
+            size: 'small',
+          },
+          style: {
+            transform: `translate(14px, var(${labelY}, 9px)) scale(1)`,
+          },
         },
-      },
-      {
-        props: ({ variant, ownerState, size }) =>
-          variant === 'filled' && ownerState.shrink && size === 'small',
-        style: {
-          transform: 'translate(12px, 4px) scale(0.75)',
+        {
+          props: ({ variant, ownerState }) => variant === 'outlined' && ownerState.shrink,
+          style: {
+            userSelect: 'none',
+            pointerEvents: 'auto',
+            // Theoretically, we should have (8+5)*2/0.75 = 34px
+            // but it feels a better when it bleeds a bit on the left, so 32px.
+            maxWidth: 'calc(133% - 32px)',
+            transform: 'translate(14px, -9px) scale(0.75)',
+          },
         },
-      },
-      {
-        props: {
-          variant: 'outlined',
-        },
-        style: {
-          // see comment above on filled.zIndex
-          zIndex: 1,
-          pointerEvents: 'none',
-          // Resting Y is a generic seam; the sibling input owns its value (see
-          // OutlinedInput's `:has` rule). Default is today's literal.
-          transform: 'translate(14px, var(--InputLabel-y, 16px)) scale(1)',
-          maxWidth: 'calc(100% - 24px)',
-        },
-      },
-      {
-        props: {
-          variant: 'outlined',
-          size: 'small',
-        },
-        style: {
-          transform: 'translate(14px, var(--InputLabel-y, 9px)) scale(1)',
-        },
-      },
-      {
-        props: ({ variant, ownerState }) => variant === 'outlined' && ownerState.shrink,
-        style: {
-          userSelect: 'none',
-          pointerEvents: 'auto',
-          // Theoretically, we should have (8+5)*2/0.75 = 34px
-          // but it feels a better when it bleeds a bit on the left, so 32px.
-          maxWidth: 'calc(133% - 32px)',
-          transform: 'translate(14px, -9px) scale(0.75)',
-        },
-      },
-    ],
-  })),
+      ],
+    };
+  }),
 );
 
 const InputLabel = React.forwardRef(function InputLabel(inProps, ref) {

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -47,8 +47,9 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
   memoTheme(({ theme }) => {
     const borderColor =
       theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
-    // Public density tokens honor cssVarPrefix (default "mui"); internal `--_*`
-    // defaults stay unprefixed (private, co-located). See ADR-0003.
+    // Material UI layer: public sized tokens honor cssVarPrefix (default "mui").
+    // Agnostic seams (`--comp-padBlock`, `--comp-padInline`, `--comp-labelY`) and
+    // internal `--_*` defaults are literal and unprefixed. See ADR-0003.
     const v = getOutlinedInputVars(theme);
     return {
       // Density adapter (docs/adr/0001): each padding literal becomes
@@ -61,7 +62,7 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
       // sibling, so reach it via :has and derive its resting-Y seam straight from
       // the public sized token. Medium resolves to 16px (16.5 - 0.5 rounding).
       [`.${inputLabelClasses.root}:has(~ &)`]: {
-        [v.labelY]: `calc(var(${v.mediumPadBlock}, 16.5px) - 0.5px)`,
+        '--comp-labelY': `calc(var(${v.mediumPadBlock}, 16.5px) - 0.5px)`,
       },
       position: 'relative',
       borderRadius: (theme.vars || theme).shape.borderRadius,
@@ -106,7 +107,7 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           style: {
             // Small label resolves to 9px (8.5 + 0.5).
             [`.${inputLabelClasses.root}:has(~ &)`]: {
-              [v.labelY]: `calc(var(${v.smallPadBlock}, 8.5px) + 0.5px)`,
+              '--comp-labelY': `calc(var(${v.smallPadBlock}, 8.5px) + 0.5px)`,
             },
           },
         },
@@ -114,28 +115,28 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           props: ({ ownerState }) => ownerState.startAdornment,
           style: {
             '--_padInline': '14px',
-            [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
-            paddingLeft: `var(${v.padInline}, var(--_padInline))`,
+            '--comp-padInline': `var(${v.mediumPadInline}, var(--_padInline))`,
+            paddingLeft: 'var(--comp-padInline, var(--_padInline))',
           },
         },
         {
           props: ({ ownerState, size }) => ownerState.startAdornment && size === 'small',
           style: {
-            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
+            '--comp-padInline': `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
         {
           props: ({ ownerState }) => ownerState.endAdornment,
           style: {
             '--_padInline': '14px',
-            [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
-            paddingRight: `var(${v.padInline}, var(--_padInline))`,
+            '--comp-padInline': `var(${v.mediumPadInline}, var(--_padInline))`,
+            paddingRight: 'var(--comp-padInline, var(--_padInline))',
           },
         },
         {
           props: ({ ownerState, size }) => ownerState.endAdornment && size === 'small',
           style: {
-            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
+            '--comp-padInline': `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
         {
@@ -143,17 +144,18 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           style: {
             '--_padBlock': '16.5px',
             '--_padInline': '14px',
-            [v.padBlock]: `var(${v.mediumPadBlock}, var(--_padBlock))`,
-            [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
-            padding: `var(${v.padBlock}, var(--_padBlock)) var(${v.padInline}, var(--_padInline))`,
+            '--comp-padBlock': `var(${v.mediumPadBlock}, var(--_padBlock))`,
+            '--comp-padInline': `var(${v.mediumPadInline}, var(--_padInline))`,
+            padding:
+              'var(--comp-padBlock, var(--_padBlock)) var(--comp-padInline, var(--_padInline))',
           },
         },
         {
           props: ({ ownerState, size }) => ownerState.multiline && size === 'small',
           style: {
             '--_padBlock': '8.5px',
-            [v.padBlock]: `var(${v.smallPadBlock}, var(--_padBlock))`,
-            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
+            '--comp-padBlock': `var(${v.smallPadBlock}, var(--_padBlock))`,
+            '--comp-padInline': `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
       ],
@@ -184,14 +186,14 @@ const OutlinedInputInput = styled(InputBaseInput, {
   memoTheme(({ theme }) => {
     const v = getOutlinedInputVars(theme);
     return {
-      // Both axes: `var(--seam, var(--_<key>))`, both sized — each seam routes the
-      // per-size public token over the internal default, specialized by the size
-      // variant below. Defaults are the Material px (inline 14px both sizes).
+      // Both axes route the per-size public token over the internal default into
+      // the literal agnostic seam (`var(--comp-<key>, var(--_<key>))`), specialized
+      // by the size variant below. Defaults are the Material px (inline 14px).
       '--_padBlock': '16.5px',
       '--_padInline': '14px',
-      [v.padBlock]: `var(${v.mediumPadBlock}, var(--_padBlock))`,
-      [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
-      padding: `var(${v.padBlock}, var(--_padBlock)) var(${v.padInline}, var(--_padInline))`,
+      '--comp-padBlock': `var(${v.mediumPadBlock}, var(--_padBlock))`,
+      '--comp-padInline': `var(${v.mediumPadInline}, var(--_padInline))`,
+      padding: 'var(--comp-padBlock, var(--_padBlock)) var(--comp-padInline, var(--_padInline))',
       '&:-webkit-autofill': {
         ...(!theme.vars && {
           WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
@@ -211,8 +213,8 @@ const OutlinedInputInput = styled(InputBaseInput, {
           props: { size: 'small' },
           style: {
             '--_padBlock': '8.5px',
-            [v.padBlock]: `var(${v.smallPadBlock}, var(--_padBlock))`,
-            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
+            '--comp-padBlock': `var(${v.smallPadBlock}, var(--_padBlock))`,
+            '--comp-padInline': `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
         {

--- a/packages/mui-material/src/OutlinedInput/OutlinedInput.js
+++ b/packages/mui-material/src/OutlinedInput/OutlinedInput.js
@@ -12,6 +12,7 @@ import createSimplePaletteValueFilter from '../utils/createSimplePaletteValueFil
 import { useDefaultProps } from '../DefaultPropsProvider';
 import outlinedInputClasses, { getOutlinedInputUtilityClass } from './outlinedInputClasses';
 import inputLabelClasses from '../InputLabel/inputLabelClasses';
+import { getOutlinedInputVars } from './outlinedInputVars';
 import InputBase, {
   rootOverridesResolver as inputBaseRootOverridesResolver,
   inputOverridesResolver as inputBaseInputOverridesResolver,
@@ -46,6 +47,9 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
   memoTheme(({ theme }) => {
     const borderColor =
       theme.palette.mode === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)';
+    // Public density tokens honor cssVarPrefix (default "mui"); internal `--_*`
+    // defaults stay unprefixed (private, co-located). See ADR-0003.
+    const v = getOutlinedInputVars(theme);
     return {
       // Density adapter (docs/adr/0001): each padding literal becomes
       // `var(--seam, var(--_<key>))`, tokenized in place. Both axes are sized —
@@ -57,7 +61,7 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
       // sibling, so reach it via :has and derive its resting-Y seam straight from
       // the public sized token. Medium resolves to 16px (16.5 - 0.5 rounding).
       [`.${inputLabelClasses.root}:has(~ &)`]: {
-        '--InputLabel-y': 'calc(var(--OutlinedInput-medium-padBlock, 16.5px) - 0.5px)',
+        [v.labelY]: `calc(var(${v.mediumPadBlock}, 16.5px) - 0.5px)`,
       },
       position: 'relative',
       borderRadius: (theme.vars || theme).shape.borderRadius,
@@ -102,7 +106,7 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           style: {
             // Small label resolves to 9px (8.5 + 0.5).
             [`.${inputLabelClasses.root}:has(~ &)`]: {
-              '--InputLabel-y': 'calc(var(--OutlinedInput-small-padBlock, 8.5px) + 0.5px)',
+              [v.labelY]: `calc(var(${v.smallPadBlock}, 8.5px) + 0.5px)`,
             },
           },
         },
@@ -110,28 +114,28 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           props: ({ ownerState }) => ownerState.startAdornment,
           style: {
             '--_padInline': '14px',
-            '--OutlinedInput-padInline': 'var(--OutlinedInput-medium-padInline, var(--_padInline))',
-            paddingLeft: 'var(--OutlinedInput-padInline, var(--_padInline))',
+            [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
+            paddingLeft: `var(${v.padInline}, var(--_padInline))`,
           },
         },
         {
           props: ({ ownerState, size }) => ownerState.startAdornment && size === 'small',
           style: {
-            '--OutlinedInput-padInline': 'var(--OutlinedInput-small-padInline, var(--_padInline))',
+            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
         {
           props: ({ ownerState }) => ownerState.endAdornment,
           style: {
             '--_padInline': '14px',
-            '--OutlinedInput-padInline': 'var(--OutlinedInput-medium-padInline, var(--_padInline))',
-            paddingRight: 'var(--OutlinedInput-padInline, var(--_padInline))',
+            [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
+            paddingRight: `var(${v.padInline}, var(--_padInline))`,
           },
         },
         {
           props: ({ ownerState, size }) => ownerState.endAdornment && size === 'small',
           style: {
-            '--OutlinedInput-padInline': 'var(--OutlinedInput-small-padInline, var(--_padInline))',
+            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
         {
@@ -139,18 +143,17 @@ const OutlinedInputRoot = styled(InputBaseRoot, {
           style: {
             '--_padBlock': '16.5px',
             '--_padInline': '14px',
-            '--OutlinedInput-padBlock': 'var(--OutlinedInput-medium-padBlock, var(--_padBlock))',
-            '--OutlinedInput-padInline': 'var(--OutlinedInput-medium-padInline, var(--_padInline))',
-            padding:
-              'var(--OutlinedInput-padBlock, var(--_padBlock)) var(--OutlinedInput-padInline, var(--_padInline))',
+            [v.padBlock]: `var(${v.mediumPadBlock}, var(--_padBlock))`,
+            [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
+            padding: `var(${v.padBlock}, var(--_padBlock)) var(${v.padInline}, var(--_padInline))`,
           },
         },
         {
           props: ({ ownerState, size }) => ownerState.multiline && size === 'small',
           style: {
             '--_padBlock': '8.5px',
-            '--OutlinedInput-padBlock': 'var(--OutlinedInput-small-padBlock, var(--_padBlock))',
-            '--OutlinedInput-padInline': 'var(--OutlinedInput-small-padInline, var(--_padInline))',
+            [v.padBlock]: `var(${v.smallPadBlock}, var(--_padBlock))`,
+            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
           },
         },
       ],
@@ -178,59 +181,61 @@ const OutlinedInputInput = styled(InputBaseInput, {
   slot: 'Input',
   overridesResolver: inputBaseInputOverridesResolver,
 })(
-  memoTheme(({ theme }) => ({
-    // Both axes: `var(--seam, var(--_<key>))`, both sized — each seam routes the
-    // per-size public token over the internal default, specialized by the size
-    // variant below. Defaults are the Material px (inline 14px both sizes).
-    '--_padBlock': '16.5px',
-    '--_padInline': '14px',
-    '--OutlinedInput-padBlock': 'var(--OutlinedInput-medium-padBlock, var(--_padBlock))',
-    '--OutlinedInput-padInline': 'var(--OutlinedInput-medium-padInline, var(--_padInline))',
-    padding:
-      'var(--OutlinedInput-padBlock, var(--_padBlock)) var(--OutlinedInput-padInline, var(--_padInline))',
-    '&:-webkit-autofill': {
-      ...(!theme.vars && {
-        WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
-        WebkitTextFillColor: theme.palette.mode === 'light' ? null : '#fff',
-        caretColor: theme.palette.mode === 'light' ? null : '#fff',
-      }),
-      borderRadius: 'inherit',
-      ...(theme.vars &&
-        theme.applyStyles('dark', {
-          WebkitBoxShadow: '0 0 0 100px #266798 inset',
-          WebkitTextFillColor: '#fff',
-          caretColor: '#fff',
-        })),
-    },
-    variants: [
-      {
-        props: { size: 'small' },
-        style: {
-          '--_padBlock': '8.5px',
-          '--OutlinedInput-padBlock': 'var(--OutlinedInput-small-padBlock, var(--_padBlock))',
-          '--OutlinedInput-padInline': 'var(--OutlinedInput-small-padInline, var(--_padInline))',
-        },
+  memoTheme(({ theme }) => {
+    const v = getOutlinedInputVars(theme);
+    return {
+      // Both axes: `var(--seam, var(--_<key>))`, both sized — each seam routes the
+      // per-size public token over the internal default, specialized by the size
+      // variant below. Defaults are the Material px (inline 14px both sizes).
+      '--_padBlock': '16.5px',
+      '--_padInline': '14px',
+      [v.padBlock]: `var(${v.mediumPadBlock}, var(--_padBlock))`,
+      [v.padInline]: `var(${v.mediumPadInline}, var(--_padInline))`,
+      padding: `var(${v.padBlock}, var(--_padBlock)) var(${v.padInline}, var(--_padInline))`,
+      '&:-webkit-autofill': {
+        ...(!theme.vars && {
+          WebkitBoxShadow: theme.palette.mode === 'light' ? null : '0 0 0 100px #266798 inset',
+          WebkitTextFillColor: theme.palette.mode === 'light' ? null : '#fff',
+          caretColor: theme.palette.mode === 'light' ? null : '#fff',
+        }),
+        borderRadius: 'inherit',
+        ...(theme.vars &&
+          theme.applyStyles('dark', {
+            WebkitBoxShadow: '0 0 0 100px #266798 inset',
+            WebkitTextFillColor: '#fff',
+            caretColor: '#fff',
+          })),
       },
-      {
-        props: ({ ownerState }) => ownerState.multiline,
-        style: {
-          padding: 0,
+      variants: [
+        {
+          props: { size: 'small' },
+          style: {
+            '--_padBlock': '8.5px',
+            [v.padBlock]: `var(${v.smallPadBlock}, var(--_padBlock))`,
+            [v.padInline]: `var(${v.smallPadInline}, var(--_padInline))`,
+          },
         },
-      },
-      {
-        props: ({ ownerState }) => ownerState.startAdornment,
-        style: {
-          paddingLeft: 0,
+        {
+          props: ({ ownerState }) => ownerState.multiline,
+          style: {
+            padding: 0,
+          },
         },
-      },
-      {
-        props: ({ ownerState }) => ownerState.endAdornment,
-        style: {
-          paddingRight: 0,
+        {
+          props: ({ ownerState }) => ownerState.startAdornment,
+          style: {
+            paddingLeft: 0,
+          },
         },
-      },
-    ],
-  })),
+        {
+          props: ({ ownerState }) => ownerState.endAdornment,
+          style: {
+            paddingRight: 0,
+          },
+        },
+      ],
+    };
+  }),
 );
 
 const OutlinedInput = React.forwardRef(function OutlinedInput(inProps, ref) {

--- a/packages/mui-material/src/OutlinedInput/index.js
+++ b/packages/mui-material/src/OutlinedInput/index.js
@@ -2,3 +2,5 @@ export { default } from './OutlinedInput';
 
 export { default as outlinedInputClasses } from './outlinedInputClasses';
 export * from './outlinedInputClasses';
+
+export { outlinedInputVars, getOutlinedInputVars } from './outlinedInputVars';

--- a/packages/mui-material/src/OutlinedInput/outlinedInputVars.ts
+++ b/packages/mui-material/src/OutlinedInput/outlinedInputVars.ts
@@ -1,18 +1,17 @@
 import { makeComponentVars } from '../styles/tokenAccess';
 
 /**
- * OutlinedInput density token identities (ADR-0003): block + inline padding
- * (both sized), plus the `InputLabel-y` seam the `:has` bridge drives on the
- * floating label.
+ * OutlinedInput density token identities (ADR-0003) — the Material UI layer's
+ * public sized knobs (block + inline padding, prefixed via
+ * `getOutlinedInputVars`). The agnostic seams (`--comp-padBlock`,
+ * `--comp-padInline`, and the `--comp-labelY` the `:has` bridge drives on the
+ * floating label) are literal and unprefixed, so they live outside this map.
  */
 export const outlinedInputVars = {
-  padBlock: 'OutlinedInput-padBlock',
-  padInline: 'OutlinedInput-padInline',
   smallPadBlock: 'OutlinedInput-small-padBlock',
   mediumPadBlock: 'OutlinedInput-medium-padBlock',
   smallPadInline: 'OutlinedInput-small-padInline',
   mediumPadInline: 'OutlinedInput-medium-padInline',
-  labelY: 'InputLabel-y',
 } as const;
 
 export const getOutlinedInputVars = makeComponentVars(outlinedInputVars);

--- a/packages/mui-material/src/OutlinedInput/outlinedInputVars.ts
+++ b/packages/mui-material/src/OutlinedInput/outlinedInputVars.ts
@@ -1,0 +1,18 @@
+import { makeComponentVars } from '../styles/tokenAccess';
+
+/**
+ * OutlinedInput density token identities (ADR-0003): block + inline padding
+ * (both sized), plus the `InputLabel-y` seam the `:has` bridge drives on the
+ * floating label.
+ */
+export const outlinedInputVars = {
+  padBlock: 'OutlinedInput-padBlock',
+  padInline: 'OutlinedInput-padInline',
+  smallPadBlock: 'OutlinedInput-small-padBlock',
+  mediumPadBlock: 'OutlinedInput-medium-padBlock',
+  smallPadInline: 'OutlinedInput-small-padInline',
+  mediumPadInline: 'OutlinedInput-medium-padInline',
+  labelY: 'InputLabel-y',
+} as const;
+
+export const getOutlinedInputVars = makeComponentVars(outlinedInputVars);

--- a/packages/mui-material/src/styles/enhanceDensity.ts
+++ b/packages/mui-material/src/styles/enhanceDensity.ts
@@ -393,18 +393,18 @@ export default function enhanceDensity<
             // The outlined label resting-Y tracks the input's block padding, but
             // the label is a preceding sibling — it can't read the input's
             // `--OutlinedInput-*-padBlock` (custom props don't inherit sibling ->
-            // sibling). So derive `--InputLabel-y` straight from the density step
-            // (which the label DOES inherit from `:root`), matching the
-            // component's -0.5/+0.5 rounding per size.
+            // sibling). So drive the agnostic `--comp-labelY` seam straight from
+            // the density step (which the label DOES inherit from `:root`),
+            // matching the component's -0.5/+0.5 rounding per size.
             [`.${inputLabelClasses.root}:has(~ &)`]: {
-              [pv('InputLabel-y')]: `calc(${varRefs.md} - 0.5px)`,
+              '--comp-labelY': `calc(${varRefs.md} - 0.5px)`,
             },
             variants: [
               {
                 props: { size: 'small' },
                 style: {
                   [`.${inputLabelClasses.root}:has(~ &)`]: {
-                    [pv('InputLabel-y')]: `calc(${varRefs.sm} + 0.5px)`,
+                    '--comp-labelY': `calc(${varRefs.sm} + 0.5px)`,
                   },
                 },
               },

--- a/packages/mui-material/src/styles/enhanceDensity.ts
+++ b/packages/mui-material/src/styles/enhanceDensity.ts
@@ -84,6 +84,12 @@ export default function enhanceDensity<
     return acc;
   }, {} as DensityScale);
 
+  // Public token name, prefix-guarded to match the component resolver (ADR-0003):
+  // prefixed when the theme has a cssVarPrefix, bare otherwise. Only the converted
+  // components (Button, OutlinedInput, InputLabel) use it; the rest stay unprefixed.
+  const prefix = (themeInput as any).cssVarPrefix;
+  const pv = (name: string) => `--${prefix ? `${prefix}-` : ''}${name}`;
+
   const theme = { ...themeInput } as T & { density: DensityScale };
   theme.density = scale;
   theme.vars = { ...themeInput.vars, density: varRefs };
@@ -114,9 +120,9 @@ export default function enhanceDensity<
           {
             // Sized-only: each size's `pad` shorthand (block inline) maps to its
             // own density step, so tuning the scale keeps the per-size matrix.
-            '--Button-small-pad': `${varRefs.xxs} ${varRefs.sm}`,
-            '--Button-medium-pad': `${varRefs.xs} ${varRefs.lg}`,
-            '--Button-large-pad': `${varRefs.sm} ${varRefs.xl}`,
+            [pv('Button-small-pad')]: `${varRefs.xxs} ${varRefs.sm}`,
+            [pv('Button-medium-pad')]: `${varRefs.xs} ${varRefs.lg}`,
+            [pv('Button-large-pad')]: `${varRefs.sm} ${varRefs.xl}`,
           },
         ],
       },
@@ -380,10 +386,10 @@ export default function enhanceDensity<
           {
             // Sized block/inline padding per size; block < inline to keep the
             // input's 16.5/14 feel.
-            '--OutlinedInput-medium-padBlock': varRefs.md,
-            '--OutlinedInput-small-padBlock': varRefs.sm,
-            '--OutlinedInput-medium-padInline': varRefs.lg,
-            '--OutlinedInput-small-padInline': varRefs.md,
+            [pv('OutlinedInput-medium-padBlock')]: varRefs.md,
+            [pv('OutlinedInput-small-padBlock')]: varRefs.sm,
+            [pv('OutlinedInput-medium-padInline')]: varRefs.lg,
+            [pv('OutlinedInput-small-padInline')]: varRefs.md,
             // The outlined label resting-Y tracks the input's block padding, but
             // the label is a preceding sibling — it can't read the input's
             // `--OutlinedInput-*-padBlock` (custom props don't inherit sibling ->
@@ -391,14 +397,14 @@ export default function enhanceDensity<
             // (which the label DOES inherit from `:root`), matching the
             // component's -0.5/+0.5 rounding per size.
             [`.${inputLabelClasses.root}:has(~ &)`]: {
-              '--InputLabel-y': `calc(${varRefs.md} - 0.5px)`,
+              [pv('InputLabel-y')]: `calc(${varRefs.md} - 0.5px)`,
             },
             variants: [
               {
                 props: { size: 'small' },
                 style: {
                   [`.${inputLabelClasses.root}:has(~ &)`]: {
-                    '--InputLabel-y': `calc(${varRefs.sm} + 0.5px)`,
+                    [pv('InputLabel-y')]: `calc(${varRefs.sm} + 0.5px)`,
                   },
                 },
               },

--- a/packages/mui-material/src/styles/tokenAccess.ts
+++ b/packages/mui-material/src/styles/tokenAccess.ts
@@ -1,0 +1,41 @@
+/**
+ * Density token name resolution (ADR-0003). The prefix tracks the css-var
+ * feature: a theme created with `cssVariables` carries `cssVarPrefix` (default
+ * `mui`), so tokens resolve to `--mui-Button-pad`; a plain `createTheme()` has
+ * no prefix, so they resolve to `--Button-pad`. The component internals and the
+ * consumer both call the same resolver on the same theme, so the emitted name
+ * and the targeted name can never drift.
+ */
+
+interface PrefixedTheme {
+  cssVarPrefix?: string | undefined;
+}
+
+/** Bare (unwrapped) css-var name for a single ad-hoc field, prefix-guarded. */
+export const varName = (theme: PrefixedTheme | undefined, field: string): string =>
+  `--${theme?.cssVarPrefix ? `${theme.cssVarPrefix}-` : ''}${field}`;
+
+/**
+ * Build a cached, theme-bound resolver from a component's key map. The resolved
+ * map depends only on `cssVarPrefix` (domain ≈ `{ '', 'mui' }`), so it's
+ * memoized per prefix: first call builds + freezes, every later call is an O(1)
+ * lookup returning the shared object — no per-call allocation, multi-field free.
+ */
+export function makeComponentVars<T extends Record<string, string>>(keyMap: T) {
+  const cache = new Map<string, Readonly<Record<keyof T, string>>>();
+  return (theme?: PrefixedTheme): Readonly<Record<keyof T, string>> => {
+    const prefix = theme?.cssVarPrefix ?? '';
+    let vars = cache.get(prefix);
+    if (vars === undefined) {
+      const resolved = {} as Record<keyof T, string>;
+      for (const key in keyMap) {
+        if (Object.prototype.hasOwnProperty.call(keyMap, key)) {
+          resolved[key] = `--${prefix ? `${prefix}-` : ''}${keyMap[key]}`;
+        }
+      }
+      vars = Object.freeze(resolved);
+      cache.set(prefix, vars);
+    }
+    return vars;
+  };
+}


### PR DESCRIPTION
**Stacked on #48624** (base = `exp/css-var-density-adapter`), so this diff is **only** the variable-prefix work. Not intended to merge — opened to show the diff for the prefix decision (RFC open question 1).

## What this explores

Make the density tokens prefixed, and find the *cleanest* implementation so the team can judge whether the added complexity is acceptable (measure the floor, not an inflated cost).

**Decision:** tokens carry the theme prefix, and the prefix **tracks the css-var feature**:
- `createTheme({ cssVariables: true })` → `--mui-Button-pad`
- plain `createTheme()` → bare `--Button-pad`

**One resolver, shared by component _and_ consumer** (`getButtonVars(theme)`), so the emitted name and the targeted name are produced by the same function on the same theme — they can't drift. Cached by `cssVarPrefix`; returns bare names; the `as const` key map is the typed handle.

```js
import { getButtonVars } from '@mui/material/Button';
const v = getButtonVars(theme);
<Box sx={{ [v.smallPad]: '2px 8px' }}>…</Box>
```

## Rejected (and why)
- `theme.vars.Button.*` — forces a core→component import inversion; a `Proxy` workaround fights Pigment's theme serialization
- `theme.getCssVar` for tokens — returns the wrapped `var(…)` form, invalid as a custom-property key (the dominant action is *setting*); also absent on a plain `createTheme()`
- forced `cssVarPrefix: 'mui'` on every theme — bolts a css-var concept onto non-css-var themes
- custom-size inline routing — removed a `useTheme()` call from every Button render

## Cost the team is being asked to accept
1. **Mode-dependent public name** (`--mui-Button-*` vs `--Button-*`) → presets aren't portable across the cssVariables boundary.
2. Tokens are theme-resolved → consumers call `getButtonVars(theme)` instead of a hand-typed constant.

## Scope
Button + OutlinedInput (+ InputLabel `:has` seam); `enhanceDensity` blocks guarded to match. Default (no-token) render unchanged → Argos zero-diff.

Design: `docs/adr/0003-density-var-prefix.md` · Demo: `/experiments/density-var-prefix`
