### PR TITLE
[prototype] Density Epic 2 — MenuItem coverage (dense axis)

### DIFF
--- a/docs/pages/experiments/density-fixture.tsx
+++ b/docs/pages/experiments/density-fixture.tsx
@@ -28,6 +28,24 @@ const scopes: Record<string, Record<string, React.CSSProperties>> = {
       ['--Button-large-pad' as any]: '16px 30px',
     },
   },
+  MenuItem: {
+    dense: {
+      ['--MenuItem-minHeight' as any]: '36px',
+      ['--MenuItem-block-pad' as any]: '3px',
+      ['--MenuItem-inline-pad' as any]: '10px',
+      ['--MenuItem-dense-minHeight' as any]: '26px',
+      ['--MenuItem-dense-block-pad' as any]: '2px',
+      ['--MenuItem-dense-inline-pad' as any]: '8px',
+    },
+    loose: {
+      ['--MenuItem-minHeight' as any]: '60px',
+      ['--MenuItem-block-pad' as any]: '12px',
+      ['--MenuItem-inline-pad' as any]: '28px',
+      ['--MenuItem-dense-minHeight' as any]: '44px',
+      ['--MenuItem-dense-block-pad' as any]: '8px',
+      ['--MenuItem-dense-inline-pad' as any]: '20px',
+    },
+  },
 };
 
 export default function DensityFixture() {

--- a/docs/pages/experiments/density-fixture.tsx
+++ b/docs/pages/experiments/density-fixture.tsx
@@ -31,19 +31,19 @@ const scopes: Record<string, Record<string, React.CSSProperties>> = {
   MenuItem: {
     dense: {
       ['--MenuItem-minHeight' as any]: '36px',
-      ['--MenuItem-block-pad' as any]: '3px',
-      ['--MenuItem-inline-pad' as any]: '10px',
+      ['--MenuItem-blockPad' as any]: '3px',
+      ['--MenuItem-inlinePad' as any]: '10px',
       ['--MenuItem-dense-minHeight' as any]: '26px',
-      ['--MenuItem-dense-block-pad' as any]: '2px',
-      ['--MenuItem-dense-inline-pad' as any]: '8px',
+      ['--MenuItem-dense-blockPad' as any]: '2px',
+      ['--MenuItem-dense-inlinePad' as any]: '8px',
     },
     loose: {
       ['--MenuItem-minHeight' as any]: '60px',
-      ['--MenuItem-block-pad' as any]: '12px',
-      ['--MenuItem-inline-pad' as any]: '28px',
+      ['--MenuItem-blockPad' as any]: '12px',
+      ['--MenuItem-inlinePad' as any]: '28px',
       ['--MenuItem-dense-minHeight' as any]: '44px',
-      ['--MenuItem-dense-block-pad' as any]: '8px',
-      ['--MenuItem-dense-inline-pad' as any]: '20px',
+      ['--MenuItem-dense-blockPad' as any]: '8px',
+      ['--MenuItem-dense-inlinePad' as any]: '20px',
     },
   },
 };

--- a/docs/pages/experiments/density-playground.tsx
+++ b/docs/pages/experiments/density-playground.tsx
@@ -11,6 +11,10 @@ import FormLabel from '@mui/material/FormLabel';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
+import MenuList from '@mui/material/MenuList';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import InboxIcon from '@mui/icons-material/Inbox';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
@@ -173,6 +177,29 @@ function ButtonMatrix({
   );
 }
 
+function MenuItemMatrix() {
+  return (
+    <MenuList sx={{ mt: 1, width: 240, border: '1px solid', borderColor: 'divider' }}>
+      <MenuItem>Default item</MenuItem>
+      <MenuItem selected>Selected item</MenuItem>
+      <MenuItem>
+        <ListItemIcon>
+          <InboxIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>With icon</ListItemText>
+      </MenuItem>
+      <MenuItem divider>With divider</MenuItem>
+      <MenuItem dense>Dense item</MenuItem>
+      <MenuItem dense>
+        <ListItemIcon>
+          <InboxIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Dense + icon</ListItemText>
+      </MenuItem>
+    </MenuList>
+  );
+}
+
 const COMPONENT_DEFS = {
   Button: {
     canvasLabel: 'Button (color="primary")',
@@ -180,6 +207,15 @@ const COMPONENT_DEFS = {
     fields: SIZES.map((size) => ({ key: `${size}Pad`, cssVar: buttonVar(size) })),
     prefill: { smallPad: 'xxs sm', mediumPad: 'xs lg', largePad: 'sm xl' },
     renderMatrix: (args) => <ButtonMatrix {...args} />,
+  },
+  MenuItem: {
+    canvasLabel: 'MenuItem (default + dense) — preset-driven',
+    // Preset-driven only: MenuItem reflows via enhance*Density's MuiMenuItem
+    // mapping; no per-element mapping inputs (its dense axis differs from
+    // Button's sized pads). Flip the preset to see it reflow.
+    fields: [],
+    prefill: {},
+    renderMatrix: () => <MenuItemMatrix />,
   },
 } satisfies Record<string, DensityComponentDef>;
 

--- a/docs/src/modules/components/densityDemos.tsx
+++ b/docs/src/modules/components/densityDemos.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
+import MenuList from '@mui/material/MenuList';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import InboxIcon from '@mui/icons-material/Inbox';
 
-// Shared density demo matrix for the CSS-var density adapter (Button only).
+// Shared density demo matrix for the CSS-var density adapter.
 // Consumed by the screenshot fixture (density-fixture). `level=default` (no token
 // overrides) must stay pixel-identical to the pre-change baseline.
 const demos: Record<string, React.ReactNode> = {
@@ -22,6 +27,31 @@ const demos: Record<string, React.ReactNode> = {
         </Stack>
       ))}
     </Stack>
+  ),
+  MenuItem: (
+    // MenuItem requires a MenuList/Menu ancestor (MenuListContext).
+    <MenuList sx={{ width: 220, border: '1px solid', borderColor: 'divider' }}>
+      <MenuItem>Default item</MenuItem>
+      <MenuItem selected>Selected item</MenuItem>
+      <MenuItem>
+        <ListItemIcon>
+          <InboxIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>With icon</ListItemText>
+      </MenuItem>
+      <MenuItem divider>With divider</MenuItem>
+      <MenuItem disableGutters>No gutters</MenuItem>
+      <MenuItem dense>Dense item</MenuItem>
+      <MenuItem dense>
+        <ListItemIcon>
+          <InboxIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Dense + icon</ListItemText>
+      </MenuItem>
+      <MenuItem dense disableGutters>
+        Dense no gutters
+      </MenuItem>
+    </MenuList>
   ),
 };
 

--- a/packages/mui-material/src/MenuItem/MenuItem.js
+++ b/packages/mui-material/src/MenuItem/MenuItem.js
@@ -20,6 +20,7 @@ import { listItemTextClasses } from '../ListItemText';
 import { useMenuListContext } from '../MenuList/MenuListContext';
 import { useSelectFocusSource } from '../Select/utils';
 import menuItemClasses, { getMenuItemUtilityClass } from './menuItemClasses';
+import { private_menuItemVars as menuItemVars } from './menuItemVars';
 
 export const overridesResolver = (props, styles) => {
   const { ownerState } = props;
@@ -61,14 +62,24 @@ const MenuItemRoot = styled(ButtonBase, {
 })(
   memoTheme(({ theme }) => ({
     ...theme.typography.body1,
+    // Material UI layer: internal sized tokens are the static, unprefixed
+    // `private_menuItemVars` map, imported here and by the `enhance*Density`
+    // presets so emitted and targeted names can't drift. Density axis is the
+    // `dense` boolean: the base routes the non-dense public token over the
+    // internal default (`--_<key>`) into the agnostic seam (`--comp-<key>`);
+    // the `dense` variant swaps in the `dense` default + dense public token.
+    '--_minHeight': '48px',
+    '--_blockPad': '6px',
+    [`--comp-minHeight`]: `var(${menuItemVars.minHeight}, var(--_minHeight))`,
+    [`--comp-blockPad`]: `var(${menuItemVars.blockPad}, var(--_blockPad))`,
     display: 'flex',
     justifyContent: 'flex-start',
     alignItems: 'center',
     position: 'relative',
     textDecoration: 'none',
-    minHeight: 48,
-    paddingTop: 6,
-    paddingBottom: 6,
+    minHeight: 'var(--comp-minHeight)',
+    paddingTop: 'var(--comp-blockPad)',
+    paddingBottom: 'var(--comp-blockPad)',
     boxSizing: 'border-box',
     whiteSpace: 'nowrap',
     '&:hover': {
@@ -131,8 +142,16 @@ const MenuItemRoot = styled(ButtonBase, {
       {
         props: ({ ownerState }) => !ownerState.disableGutters,
         style: {
-          paddingLeft: 16,
-          paddingRight: 16,
+          '--_inlinePad': '16px',
+          [`--comp-inlinePad`]: `var(${menuItemVars.inlinePad}, var(--_inlinePad))`,
+          paddingLeft: 'var(--comp-inlinePad)',
+          paddingRight: 'var(--comp-inlinePad)',
+        },
+      },
+      {
+        props: ({ ownerState }) => !ownerState.disableGutters && ownerState.dense,
+        style: {
+          [`--comp-inlinePad`]: `var(${menuItemVars.denseInlinePad}, var(--_inlinePad))`,
         },
       },
       {
@@ -153,9 +172,11 @@ const MenuItemRoot = styled(ButtonBase, {
       {
         props: ({ ownerState }) => ownerState.dense,
         style: {
-          minHeight: 32, // https://m2.material.io/components/menus#specs > Dense
-          paddingTop: 4,
-          paddingBottom: 4,
+          // https://m2.material.io/components/menus#specs > Dense
+          '--_minHeight': '32px',
+          '--_blockPad': '4px',
+          [`--comp-minHeight`]: `var(${menuItemVars.denseMinHeight}, var(--_minHeight))`,
+          [`--comp-blockPad`]: `var(${menuItemVars.denseBlockPad}, var(--_blockPad))`,
           ...theme.typography.body2,
           [`& .${listItemIconClasses.root} svg`]: {
             fontSize: '1.25rem',

--- a/packages/mui-material/src/MenuItem/index.d.ts
+++ b/packages/mui-material/src/MenuItem/index.d.ts
@@ -3,3 +3,4 @@ export * from './MenuItem';
 
 export * from './menuItemClasses';
 export { default as menuItemClasses } from './menuItemClasses';
+export { private_menuItemVars } from './menuItemVars';

--- a/packages/mui-material/src/MenuItem/index.js
+++ b/packages/mui-material/src/MenuItem/index.js
@@ -2,3 +2,4 @@ export { default } from './MenuItem';
 
 export * from './menuItemClasses';
 export { default as menuItemClasses } from './menuItemClasses';
+export { private_menuItemVars } from './menuItemVars';

--- a/packages/mui-material/src/MenuItem/menuItemVars.ts
+++ b/packages/mui-material/src/MenuItem/menuItemVars.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/naming-convention, import/prefer-default-export */
+/**
+ * MenuItem density token identities — the Material UI layer's internal
+ * designer knobs (`private_*` per the density RFC). Static, unprefixed literals
+ * imported by both the styled component AND the `enhance*Density` presets that
+ * map these to density steps, so the emitted and targeted names can't drift.
+ * The agnostic seam (`--comp-<key>`) and internal default (`--_<key>`) are the
+ * literal plumbing and live outside this map.
+ *
+ * MenuItem's compactness axis is the `dense` boolean (not small/medium/large):
+ * each sized token has a `dense` counterpart the dense variant routes to.
+ */
+export const private_menuItemVars = {
+  minHeight: '--MenuItem-minHeight',
+  denseMinHeight: '--MenuItem-dense-minHeight',
+  blockPad: '--MenuItem-block-pad',
+  denseBlockPad: '--MenuItem-dense-block-pad',
+  inlinePad: '--MenuItem-inline-pad',
+  denseInlinePad: '--MenuItem-dense-inline-pad',
+} as const;

--- a/packages/mui-material/src/MenuItem/menuItemVars.ts
+++ b/packages/mui-material/src/MenuItem/menuItemVars.ts
@@ -13,8 +13,8 @@
 export const private_menuItemVars = {
   minHeight: '--MenuItem-minHeight',
   denseMinHeight: '--MenuItem-dense-minHeight',
-  blockPad: '--MenuItem-block-pad',
-  denseBlockPad: '--MenuItem-dense-block-pad',
-  inlinePad: '--MenuItem-inline-pad',
-  denseInlinePad: '--MenuItem-dense-inline-pad',
+  blockPad: '--MenuItem-blockPad',
+  denseBlockPad: '--MenuItem-dense-blockPad',
+  inlinePad: '--MenuItem-inlinePad',
+  denseInlinePad: '--MenuItem-dense-inlinePad',
 } as const;

--- a/packages/mui-material/src/styles/enhanceComfortDensity.ts
+++ b/packages/mui-material/src/styles/enhanceComfortDensity.ts
@@ -1,5 +1,6 @@
 import { addRootOverride, applyDensity, densityVars as d, DensityScale, EnhanceableTheme } from './densityScale';
 import { private_buttonVars as buttonVars } from '../Button/buttonVars';
+import { private_menuItemVars as menuItemVars } from '../MenuItem/menuItemVars';
 
 const scale: DensityScale = {
   xxs: '6px',
@@ -17,6 +18,14 @@ export default function enhanceComfortDensity<T extends EnhanceableTheme>(theme:
     [buttonVars.smallPad]: `${d.xxs} ${d.sm}`,
     [buttonVars.mediumPad]: `${d.xs} ${d.lg}`,
     [buttonVars.largePad]: `${d.sm} ${d.xl}`,
+  });
+  addRootOverride(enhanced.components, 'MuiMenuItem', {
+    [menuItemVars.minHeight]: d.xl,
+    [menuItemVars.denseMinHeight]: d.lg,
+    [menuItemVars.blockPad]: d.xs,
+    [menuItemVars.denseBlockPad]: d.xxs,
+    [menuItemVars.inlinePad]: d.lg,
+    [menuItemVars.denseInlinePad]: d.md,
   });
   enhanced.typography = {
     ...enhanced.typography,

--- a/packages/mui-material/src/styles/enhanceCompactDensity.ts
+++ b/packages/mui-material/src/styles/enhanceCompactDensity.ts
@@ -1,5 +1,6 @@
 import { addRootOverride, applyDensity, densityVars as d, DensityScale, EnhanceableTheme } from './densityScale';
 import { private_buttonVars as buttonVars } from '../Button/buttonVars';
+import { private_menuItemVars as menuItemVars } from '../MenuItem/menuItemVars';
 
 const scale: DensityScale = {
   xxs: '2px',
@@ -17,6 +18,14 @@ export default function enhanceCompactDensity<T extends EnhanceableTheme>(theme:
     [buttonVars.smallPad]: `${d.xxs} ${d.sm}`,
     [buttonVars.mediumPad]: `${d.xs} ${d.lg}`,
     [buttonVars.largePad]: `${d.sm} ${d.xl}`,
+  });
+  addRootOverride(enhanced.components, 'MuiMenuItem', {
+    [menuItemVars.minHeight]: d.xl,
+    [menuItemVars.denseMinHeight]: d.lg,
+    [menuItemVars.blockPad]: d.xs,
+    [menuItemVars.denseBlockPad]: d.xxs,
+    [menuItemVars.inlinePad]: d.lg,
+    [menuItemVars.denseInlinePad]: d.md,
   });
   enhanced.typography = {
     ...enhanced.typography,

--- a/packages/mui-material/src/styles/enhanceNormalDensity.ts
+++ b/packages/mui-material/src/styles/enhanceNormalDensity.ts
@@ -1,5 +1,6 @@
 import { addRootOverride, applyDensity, densityVars as d, DensityScale, EnhanceableTheme } from './densityScale';
 import { private_buttonVars as buttonVars } from '../Button/buttonVars';
+import { private_menuItemVars as menuItemVars } from '../MenuItem/menuItemVars';
 
 // Explicit px (self-contained, not spacing-derived). Normal keeps today's Button
 // typography — no reflow — so only the padding→step assignment below.
@@ -19,6 +20,14 @@ export default function enhanceNormalDensity<T extends EnhanceableTheme>(theme: 
     [buttonVars.smallPad]: `${d.xxs} ${d.sm}`,
     [buttonVars.mediumPad]: `${d.xs} ${d.lg}`,
     [buttonVars.largePad]: `${d.sm} ${d.xl}`,
+  });
+  addRootOverride(enhanced.components, 'MuiMenuItem', {
+    [menuItemVars.minHeight]: d.xl,
+    [menuItemVars.denseMinHeight]: d.lg,
+    [menuItemVars.blockPad]: d.xs,
+    [menuItemVars.denseBlockPad]: d.xxs,
+    [menuItemVars.inlinePad]: d.lg,
+    [menuItemVars.denseInlinePad]: d.md,
   });
   return enhanced;
 }


### PR DESCRIPTION
## Epic 2 · Phase 1 — MenuItem density coverage

Second component in the density rollout (after Button), following the [per-component procedure](https://github.com/siriwatknp/material-ui/tree/exp/density-button-prototype). Base: `exp/density-button-prototype`.

### Model
MenuItem has no `small/medium/large` size — its compactness axis is the **`dense` boolean**. Tokenized with the same three-layer seam as Button (`--comp-<key>` over `--_<key>`), keyed on `dense`:
- base routes the non-dense public token; the `dense` variant swaps in the dense default + dense public token.
- Typography swap (`body1↔body2`, icon `1.5→1.25rem`) stays out of density scope — unchanged by any preset.

### Tokens (`private_menuItemVars`)
`minHeight / denseMinHeight`, `blockPad / denseBlockPad`, `inlinePad / denseInlinePad` → `--MenuItem-{,dense-}{minHeight,block-pad,inline-pad}`. Same map imported by the styled fn + all 3 presets (no drift); re-exported from `MenuItem/index.js`.

### Preset mapping (each `enhance*Density`)
`minHeight→xl / dense→lg`, `blockPad→xs / dense→xxs`, `inlinePad→lg / dense→md`.

### Verification
- **Static:** `@mui/material` + `docs` typecheck, eslint clean, `MenuItem.test.js` 58 pass.
- **Zero-diff gate** (`maxDiffPixels: 0`, both dense states) vs the master baseline — `unset` render pixel-identical to today (non-dense `6/16`, min-auto @≥sm; dense `32/4/16`).
- **Preset reflow** (`getComputedStyle`): non-dense block/inline pad `4/12 · 6/16 · 8/24` (compact/normal/comfort); dense minHeight `12 · 16 · 24`.
- Button gate re-run green (shared preset files unchanged in behavior).

### Note
Unlike Button, `normal` ≠ today for MenuItem's **dense** row (dense minHeight `32→16`, dense inline-pad `16→12`) — the validated steps (`denseMinHeight→lg`, `denseInlinePad→md`) hit the density scale, which has no `32`/`16` step at `normal`. Non-dense `normal` does match today. Only `unset` is the hard zero-diff gate per the epic; easy to change if `normal`-preserves-today is wanted for dense.

Also adds MenuItem to the density fixture (screenshot gate) and the playground canvas (preset-driven reflow; interactive per-token mapping stays Button-specific for now).
